### PR TITLE
Make soft_delete transparent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /test/tmp/
 /test/version_tmp/
 /tmp/
+.vscode
 
 # Used by dotenv library to load environment variables.
 # .env

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    commons_yellowme (0.11.2)
+    commons_yellowme (0.13.0)
       active_model_serializers (~> 0.10.10)
       dry-validation
       json (~> 2.0)
@@ -78,7 +78,7 @@ GEM
     dry-equalizer (0.3.0)
     dry-inflector (0.2.0)
     dry-initializer (3.0.3)
-    dry-logic (1.0.5)
+    dry-logic (1.0.6)
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.2)
       dry-equalizer (~> 0.2)
@@ -90,7 +90,7 @@ GEM
       dry-initializer (~> 3.0)
       dry-logic (~> 1.0)
       dry-types (~> 1.2)
-    dry-types (1.2.2)
+    dry-types (1.3.0)
       concurrent-ruby (~> 1.0)
       dry-container (~> 0.3)
       dry-core (~> 0.4, >= 0.4.4)
@@ -215,4 +215,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/lib/commons.rb
+++ b/lib/commons.rb
@@ -24,7 +24,7 @@ require 'commons/services/concerns/callable'
 
 # models
 require 'commons/concerns/attributes/sex'
-require 'commons/concerns/extensions/deleted'
+require 'commons/concerns/extensions/soft_deleted'
 require 'commons/concerns/guard/capitalizable'
 require 'commons/concerns/validations/undestroyable'
 

--- a/lib/commons/concerns/extensions/soft_deleted.rb
+++ b/lib/commons/concerns/extensions/soft_deleted.rb
@@ -1,23 +1,33 @@
 module Commons
   module Concerns
     module Extensions
-      module Deleted
+      module SoftDeleted
         extend ActiveSupport::Concern
 
         included do
+
           before_validation :check_not_deleted, on: [:update]
 
           def deleted?
-            raise ActiveModel::MissingAttributeError unless self.has_attribute?(:deleted_at)
+            raise ActiveModel::MissingAttributeError unless has_required_fields?
             self.deleted_at.present?
           end
+        end
+
+        def self.default_scope
+          raise ActiveModel::MissingAttributeError unless has_required_fields?
+          where(deleted_at: nil)
         end
 
         private
 
         def check_not_deleted
-          raise ActiveModel::MissingAttributeError unless self.has_attribute?(:deleted_at)
+          raise ActiveModel::MissingAttributeError unless has_required_fields?
           raise ActiveRecord::RecordInvalid if self.deleted_at_in_database.present?
+        end
+
+        def has_required_fields?
+          self.has_attribute?(:deleted_at)
         end
       end
     end

--- a/lib/commons/concerns/extensions/soft_deleted.rb
+++ b/lib/commons/concerns/extensions/soft_deleted.rb
@@ -5,18 +5,17 @@ module Commons
         extend ActiveSupport::Concern
 
         included do
-
           before_validation :check_not_deleted, on: [:update]
 
           def deleted?
             raise ActiveModel::MissingAttributeError unless has_required_fields?
             self.deleted_at.present?
           end
-        end
 
-        def self.default_scope
-          raise ActiveModel::MissingAttributeError unless has_required_fields?
-          where(deleted_at: nil)
+          def self.default_scope
+            raise ActiveModel::MissingAttributeError unless has_attribute?(:deleted_at)
+            where(deleted_at: nil)
+          end
         end
 
         private

--- a/lib/commons/formatter/regex_constants.rb
+++ b/lib/commons/formatter/regex_constants.rb
@@ -4,8 +4,8 @@ module Commons
       PROPER_NOUN = /\A\p{L}[\p{L}'\.\-]*( [\p{L}'\.\-]+)*\z/u
       CURP = /\A([A-Z][AEIOUX][A-Z]{2}\d{2}(?:0[1-9]|1[0-2])(?:0[1-9]|[12]\d|3[01])[HM](?:AS|B[CS]|C[CLMSH]|D[FG]|G[TR]|HG|JC|M[CNS]|N[ETL]|OC|PL|Q[TR]|S[PLR]|T[CSL]|VZ|YN|ZS)[B-DF-HJ-NP-TV-Z]{3}[A-Z\d])(\d)\z/
       RFC = /\A([A-ZÑ\x26]{3,4}(\d{2})(0[1-9]|1[0-2])(0[1-9]|[12]\d|3[0-1])([A-Z0-9]){2}([A0-9]))?\z/i
-      ELECTOR_KEY = /\A[A-Z]{6}\d{2}(?:0[1-9]|1[0-2])(?:0[1-9]|[12]\d|3[01])\d{2}[A-Z]\d{3}\z/
-      MX_MONEY = /\A-?\d{1,12}(\.\d{0,6})?\z/
+      ELECTOR_KEY = /\A(?:[A-Z][B-DF-HJ-NP-TV-Z]){3}\d{2}(?:0[1-9]|1[0-2])(?:0[1-9]|[12]\d|3[01])(?:0[1-9]|[12]\d|3[0-2]|99)[A-Z]\d{3}\z/
+      MONEY = /\A[+-]?\d+(\.\d{1,6})?\z/
     end
   end
 end

--- a/lib/commons/repositories/base_repository.rb
+++ b/lib/commons/repositories/base_repository.rb
@@ -4,54 +4,39 @@ module Commons
       include Singleton
 
       #
-      # Método que devuelve todos los objetos
+      # Método que devuelve todos los objetos activos
       #
-      # @return [Object,nil]
+      # @return [Arrat<Object>, nil]
       #
-      def all
-        @db_client.all
-      end
-
-      #
-      # Método que devuelve todos los objetos que no han sido eliminados
-      #
-      # @return [Object,nil]
-      #
-      def kept
-        raise ActiveModel::MissingAttributeError unless @db_client.column_names.include? "deleted_at"
-
-        @db_client.where(deleted_at: nil)
-      end
+      delegate :all, to: :@db_client
 
       #
       # Método que devuelve todos los objetos que han sido eliminados
       #
-      # @return [Object,nil]
+      # @return [Object, nil]
       #
       def deleted
-        raise ActiveModel::MissingAttributeError unless @db_client.column_names.include? "deleted_at"
+        raise ActiveModel::MissingAttributeError unless @db_client.include? Commons::Concerns::Extensions::SoftDeleted
 
-        @db_client.where.not(deleted_at: nil)
+        @db_client.unscoped.where.not(deleted_at: nil)
       end
+
+      #
+      # Método que devuelve el objeto según su ID
+      #
+      # @return [Object, nil]
+      #
+      delegate :find, to: :@db_client
 
       #
       # Método que devuelve el objeto según su ID
       #
       # @return [Object,nil]
       #
-      def find(id)
-        @db_client.find(id)
-      end
+      def find_deleted(id)
+        raise ActiveModel::MissingAttributeError unless @db_client.include? Commons::Concerns::Extensions::SoftDeleted
 
-      #
-      # Método que devuelve el objeto según su ID
-      #
-      # @return [Object,nil]
-      #
-      def find_kept(id)
-        raise ActiveModel::MissingAttributeError unless @db_client.column_names.include? "deleted_at"
-
-        @db_client.find_by!(id: id, deleted_at: nil)
+        @db_client.unscoped.where(id: id).where.not(deleted_at: nil).first
       end
 
       #
@@ -59,22 +44,17 @@ module Commons
       #
       # @return [Object,nil]
       #
-      def find_by(params)
-        @db_client.find_by(params)
-      end
+      delegate :find_by, to: :@db_client
 
       #
       # Método que devuelve el objeto según parámetros
       #
       # @return [Object,nil]
       #
-      def find_kept_by(params)
-        raise ActiveModel::MissingAttributeError unless @db_client.column_names.include? "deleted_at"
+      def find_deleted_by(params)
+        raise ActiveModel::MissingAttributeError unless @db_client.include? Commons::Concerns::Extensions::SoftDeleted
 
-        @db_client.find_by(
-          deleted_at: nil,
-          **params
-        )
+        @db_client.unscoped.where.not(deleted_at: nil).where(**params).first
       end
 
       #
@@ -84,9 +64,7 @@ module Commons
       #
       # @raise [ActiveRecord::RecordNotFound]
       #
-      def find_by!(params)
-        @db_client.find_by!(params)
-      end
+      delegate :find_by!, to: :@db_client
 
       #
       # Método que devuelve el objeto según parámetros
@@ -95,13 +73,10 @@ module Commons
       #
       # @raise [ActiveRecord::RecordNotFound]
       #
-      def find_kept_by!(params)
-        raise ActiveModel::MissingAttributeError unless @db_client.column_names.include? "deleted_at"
+      def find_deleted_by!(params)
+        raise ActiveModel::MissingAttributeError unless @db_client.include? Commons::Concerns::Extensions::SoftDeleted
 
-        @db_client.find_by!(
-          deleted_at: nil,
-          **params
-        )
+        @db_client.unscoped.where.not(deleted_at: nil).where(**params).first!
       end
 
       #
@@ -115,9 +90,10 @@ module Commons
       # @raise [ActiveRecord::RecordNotSaved]
       #
       def create!(object)
-        raise ArgumentError unless object.is_a? @db_client
+        raise ArgumentError unless object.is_a?(@db_client)
+        raise ActiveRecord::RecordInvalid.new(object) unless object.valid?
 
-        object.save!
+        save_object(object)
       end
 
       #
@@ -143,10 +119,7 @@ module Commons
       #
       # @raises [ActiveRecord::RecordInvalid]
       #
-      def find_or_create_by!(params, &block)
-        object = @db_client.find_by(params) || @db_client.create!(params, &block)
-        object
-      end
+      delegate :find_or_create_by!, to: :@db_client
 
       #
       # Método que realiza una busqueda de la primer entrada,
@@ -174,7 +147,13 @@ module Commons
       # @raise [ActiveRecord::RecordNotSaved]
       #
       def update!(object)
-        create!(object)
+        if !object.is_a?(@db_client) || object.id.blank?
+          raise ArgumentError
+        end
+
+        raise ActiveRecord::RecordInvalid.new(object) unless object.valid?
+
+        save_object(object)
       end
 
       #
@@ -203,24 +182,42 @@ module Commons
       # @raises [ActiveRecord::RecordInvalid]
       # @raises [ActiveModel::MissingAttributeError]
       #
-      def soft_delete!(id)
-        raise ActiveModel::MissingAttributeError unless @db_client.column_names.include? "deleted_at"
-
-        object = @db_client.find_by!(id: id, deleted_at: nil)
-        object.update!(deleted_at: Time.current)
-
-        object
+      def destroy!(object)
+        if @db_client.include? Commons::Concerns::Extensions::SoftDeleted
+          soft_delete!(object)
+        else
+          hard_delete!(object)
+        end
       end
 
-      private
+      protected
 
       def initialize
-        @db_client ||= class_object
+        @db_client = class_object
       end
 
       def class_object
         model_name = self.class.to_s.gsub("Repository", "")
         Object.const_get model_name
+      end
+
+      private
+
+      def save_object(object)
+        object.save
+      end
+
+      def soft_delete!(object)
+        raise ActiveModel::MissingAttributeError unless @db_client.column_names.include?("deleted_at")
+        object.update!(deleted_at: Time.current)
+
+        object
+      end
+
+      def hard_delete!(object)
+        object.destroy!
+
+        object
       end
     end
   end

--- a/lib/commons/repositories/base_repository.rb
+++ b/lib/commons/repositories/base_repository.rb
@@ -11,6 +11,14 @@ module Commons
       delegate :all, to: :@db_client
 
       #
+      # Método que devuelve todos los objetos que no han sido eliminados
+      #
+      # @return [Object,nil]
+      #
+      delegate :where, to: :@db_client
+      alias_method :query, :where
+
+      #
       # Método que devuelve todos los objetos que han sido eliminados
       #
       # @return [Object, nil]

--- a/lib/commons/version.rb
+++ b/lib/commons/version.rb
@@ -1,3 +1,3 @@
 module Commons
-  VERSION = '0.12.0'
+  VERSION = '0.13.0'.freeze
 end

--- a/spec/commons/concerns/extensions/deleted_spec.rb
+++ b/spec/commons/concerns/extensions/deleted_spec.rb
@@ -33,10 +33,8 @@ RSpec.describe Commons::Concerns::Extensions::SoftDeleted do
     end
 
     it 'when model is not soft_deletable' do
-      # given
-      employee = Employee.new
       # do
-      expect{ employee.deleted? }.to raise_error(ActiveModel::MissingAttributeError)
+      expect{ Employee.new }.to raise_error(ActiveModel::MissingAttributeError)
     end
   end
 end

--- a/spec/commons/concerns/extensions/deleted_spec.rb
+++ b/spec/commons/concerns/extensions/deleted_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Commons::Concerns::Extensions::Deleted do
+RSpec.describe Commons::Concerns::Extensions::SoftDeleted do
   let(:user) { create(:user) }
 
   subject do
@@ -18,7 +18,7 @@ RSpec.describe Commons::Concerns::Extensions::Deleted do
     it 'when deleted user' do
       # given
       user = subject
-      user = UserRepository.instance.soft_delete!(user.id)
+      user = UserRepository.instance.destroy!(user)
       # do
       expect(user.deleted?).to eq true
     end
@@ -26,13 +26,13 @@ RSpec.describe Commons::Concerns::Extensions::Deleted do
     it 'when deleted user denies save' do
       # given
       user = subject
-      user = UserRepository.instance.soft_delete!(user.id)
+      user = UserRepository.instance.destroy!(user)
       user.name = Faker::Name.first_name
       # do
       expect{ user.save }.to raise_error(ActiveRecord::RecordInvalid)
     end
 
-    it 'when model is not deletable' do
+    it 'when model is not soft_deletable' do
       # given
       employee = Employee.new
       # do

--- a/spec/commons/formatter/regex_constants_spec.rb
+++ b/spec/commons/formatter/regex_constants_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Commons::Formatter::RegexConstants do
     end
   end
 
-  describe 'CRUP' do
+  describe 'CURP' do
     context 'works when valid' do
       curp_list = [
         'BEML920313HMCLNS09',
@@ -95,6 +95,69 @@ RSpec.describe Commons::Formatter::RegexConstants do
       rfc_list.each do |rfc|
         it "for RFC #{rfc}" do
           expect(rfc =~ Commons::Formatter::RegexConstants::RFC).to be_falsey
+        end
+      end
+    end
+  end
+
+  describe 'ELECTOR_KEY' do
+    context 'works when valid' do
+      elector_list = [
+        'PXMXJX94021709H000',
+        'OXSXJX96062909H000',
+      ]
+      elector_list.each do |k|
+        it "for clave #{k}" do
+          expect(k =~ Commons::Formatter::RegexConstants::ELECTOR_KEY).to be >= 0
+        end
+      end
+    end
+
+    context 'fail when not valid' do
+      elector_list = [
+        'xxxx',
+        '11111',
+        'XAXX000000HXXYYY00'
+      ]
+      elector_list.each do |k|
+        it "for clave #{k}" do
+          expect(k =~ Commons::Formatter::RegexConstants::ELECTOR_KEY).to be_falsey
+        end
+      end
+    end
+  end
+
+  describe 'MONEY' do
+    context 'works when valid' do
+      number_list = [
+        '10.00',
+        '1',
+        '-1.0',
+        '+1.0',
+        '0.000001',
+        '10000.000',
+        '99999999999999999999999999999999999999',
+        '99999999999999999999999999999999999999.999999',
+        '0',
+      ]
+      number_list.each do |number|
+        it "for number #{number}" do
+          expect(number =~ Commons::Formatter::RegexConstants::MONEY).to be >= 0
+        end
+      end
+    end
+
+    context 'fail when not valid' do
+      number_list = [
+        '',
+        ' 0.0 ',
+        '0.0000001',
+        '$0.00',
+        '.1'
+      ]
+      number_list.each do |number|
+        it "for number #{number}" do
+          expect(number =~ Commons::Formatter::RegexConstants::MONEY).to be_falsey
         end
       end
     end

--- a/spec/commons/repositories/base_repository_spec.rb
+++ b/spec/commons/repositories/base_repository_spec.rb
@@ -23,13 +23,49 @@ RSpec.describe Commons::Repositories::BaseRepository do
       subject { UserRepository.instance.all }
 
       it do
-        expect(subject.count).to eq users_amount + deleted_users_amount
+        expect(subject.count).to eq users_amount
         expect(subject.first).to be_an_instance_of User
       end
     end
 
     context 'when no data' do
       it { expect(UserRepository.instance.all).to be_empty }
+    end
+  end
+
+  describe 'query' do
+    context 'when data exists' do
+      let(:users_amount) { 10 }
+      let(:deleted_users_amount) { 5 }
+      before do
+        users_amount.times {
+          UserRepository.instance.create_from_params!(**valid_params.to_h.symbolize_keys)
+        }
+        deleted_users_amount.times {
+          user = UserRepository.instance.create_from_params!(**valid_params.to_h.symbolize_keys)
+          UserRepository.instance.destroy!(user)
+        }
+      end
+
+      subject { UserRepository.instance.query.not(name: nil) }
+
+      it do
+        expect(subject.count).to eq users_amount
+      end
+    end
+
+    context 'when no data' do
+      let(:deleted_users_amount) { 5 }
+      before do
+        deleted_users_amount.times {
+          user = UserRepository.instance.create_from_params!(**valid_params.to_h.symbolize_keys)
+          UserRepository.instance.destroy!(user)
+        }
+      end
+
+      subject { UserRepository.instance.query.not(name: nil) }
+
+      it { expect(subject).to be_empty }
     end
   end
 
@@ -311,12 +347,12 @@ RSpec.describe Commons::Repositories::BaseRepository do
     end
 
     describe 'fails when' do
-      context 'is not a user' do
-        let(:employee) { build(:employee) }
+      context 'is not a employee' do
+        let(:user) { build(:user) }
 
         it do
           expect do
-            UserRepository.instance.create!(employee)
+            EmployeeRepository.instance.create!(user)
           end.to raise_error(ArgumentError)
         end
       end
@@ -366,11 +402,11 @@ RSpec.describe Commons::Repositories::BaseRepository do
 
     describe 'fails when' do
       context 'is not a user' do
-        let(:employee) { create(:employee) }
+        let(:user) { create(:user) }
 
         it do
           expect do
-            UserRepository.instance.update!(employee)
+            EmployeeRepository.instance.update!(user)
           end.to raise_error(ArgumentError)
         end
       end

--- a/spec/dummy/app/models/employee.rb
+++ b/spec/dummy/app/models/employee.rb
@@ -1,3 +1,3 @@
 class Employee < ApplicationRecord
-  include Commons::Concerns::Extensions::Deleted
+  include Commons::Concerns::Extensions::SoftDeleted
 end

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ApplicationRecord
   include Commons::Concerns::Attributes::Sex
-  include Commons::Concerns::Extensions::Deleted
+  include Commons::Concerns::Extensions::SoftDeleted
   include Commons::Concerns::Guard::Capitalizable
   include Commons::Concerns::Validations::Undestroyable
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,6 +48,10 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
+  # This setting enables warnings. It's recommended, but in some cases may
+  # be too noisy due to issues in dependencies.
+  config.warnings = true
+
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
 =begin


### PR DESCRIPTION
Prior this change the model and repo API need to explicitly know if it had to be soft deleted or hard deleted

This change allows the model and repo API to ignore how the model is supossed to be deleted.
Also uses `delegate` on methods already declared on the ActiveRecord class (@db_client)