### PR TITLE
Allow `Callable` to receive unnamed and named args

### DIFF
--- a/lib/commons/services/concerns/callable.rb
+++ b/lib/commons/services/concerns/callable.rb
@@ -5,8 +5,13 @@ module Commons
         extend ActiveSupport::Concern
 
         class_methods do
-          def call(*args)
-            new(*args).call
+          def call(*args, **kwargs)
+            # This approach allows thge class initializer to use regular arguments,
+            # named argumets or the mix of both.
+            # This at the same time allows the usage of Dry::Initializer
+            # https://dry-rb.org/gems/dry-initializer/3.0/
+            # And perhaps this can eventually be a defualt part of Callable Module
+            new(*args, **kwargs).call
           end
         end
       end

--- a/lib/commons/version.rb
+++ b/lib/commons/version.rb
@@ -1,3 +1,3 @@
 module Commons
-  VERSION = '0.13.0'.freeze
+  VERSION = '0.14.0'.freeze
 end


### PR DESCRIPTION
This approach allows the class that implement `Callable` to use regular arguments, named arguments or the mix of both.